### PR TITLE
fix bug in namelist-editor

### DIFF
--- a/DognameApp/src/components/namelist-editor.js
+++ b/DognameApp/src/components/namelist-editor.js
@@ -7,9 +7,11 @@ import Namelist from './namelist';
 export default class NamelistEditor extends Component {
     render() {
         return (
-            <AddText />
-            //<ShowChars /> This doesn't work
-            //<Namelist /> This doesn't work
+            <div>
+                <AddText />
+                <ShowChars />
+                <Namelist />
+            </div>
         );
     }
 }


### PR DESCRIPTION
The JSX syntax, for example this:

```
<sometag someprop="someval"><somechild /></sometag>
```

...is translated to a function call, which for the example above would be something like this:

```
sometag({someprop:"someval"},[somechild({},[])])
```

So each tag is actually a function taking two arguments; an object with props, and an array of children. 

This means that it makes no sense to return three tags, as that would be the same as returning three function calls! What you must do in this case is to wrap it in a surrounding tag.

TL;DR: A render method must always return exactly 1 tag.
